### PR TITLE
types/ngeohash fix neighbors_int() type and add error property in GeographicPoint interface

### DIFF
--- a/types/ngeohash/index.d.ts
+++ b/types/ngeohash/index.d.ts
@@ -7,6 +7,10 @@ declare namespace ngeohash {
   interface GeographicPoint {
     latitude: number;
     longitude: number;
+    error: {
+      latitude: number;
+      longitude: number;
+    }
   }
 
   type GeographicBoundingBox = [number, number, number, number];
@@ -24,7 +28,7 @@ declare namespace ngeohash {
   function decode_bbox_int(hashinteger: number, bitDepth?: number): GeographicBoundingBox;
   function bboxes_int(minlat: number, minlon: number, maxlat: number, maxlon: number, bitDepth?: number): number;
   function neighbor_int(hashinteger: number, direction: NSEW, bitDepth?: number): number;
-  function neighbors_int(hashinteger: number, bitDepth?: number): number;
+  function neighbors_int(hashinteger: number, bitDepth?: number): Array<number>;
 }
 
 declare module "ngeohash" {

--- a/types/ngeohash/ngeohash-tests.ts
+++ b/types/ngeohash/ngeohash-tests.ts
@@ -7,3 +7,8 @@ console.log(geohash.encode('37.8324', '112.5584'));
 var latlon = geohash.decode('ww8p1r4t8');
 console.log(latlon.latitude);
 console.log(latlon.longitude);
+console.log(latlon.error.latitude);
+console.log(latlon.error.longitude);
+
+console.log(geohash.encode_int(37.8324, 112.5584));
+//console.log(geohash.neighbors_int());


### PR DESCRIPTION
add error to GeographicPoint interface and fix neighbors_int() type (change from number to Array<number>)

Please fill in this template.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code. (Compile and run.)
- [x] [Add or edit tests](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#my-package-teststs) to reflect the change.
- [x] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [x] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [x] [Run `npm test <package to test>`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#running-tests).

Select one of these and delete the others:

If changing an existing definition:
- [x] Provide a URL to documentation or source code which provides context for the suggested changes: <<url here>>
- [x] If this PR brings the type definitions up to date with a new version of the JS library, update the version number in the header.
